### PR TITLE
sortOptimalLayout を reduce に変更しテスト追加

### DIFF
--- a/src/libs/grid.test.ts
+++ b/src/libs/grid.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calculateAreaInCell, enumerateGridDimensions } from "./grid";
+import { calculateAreaInCell, enumerateGridDimensions, sortOptimalLayout } from "./grid";
 
 describe("calculateAreaInCell", () => {
   it("cellのaspect ratioのほうが大きい場合、cellの高さに合わせる", () => {
@@ -75,5 +75,25 @@ describe("enumerateCellCounts", () => {
       { columns: 4, rows: 2 },
       { columns: 5, rows: 1 },
     ]);
+  });
+});
+
+describe("sortOptimalLayout", () => {
+  it("コンテナが16:9でコンテンツが3つの場合、最適レイアウトは2x2", () => {
+    const result = sortOptimalLayout({
+      containerWidth: 1920,
+      containerHeight: 1080,
+      contentCount: 3,
+      contentAspectRatio: 16 / 9,
+    });
+    expect(result[0].layout.id).toBe("2x2");
+    expect(result).toHaveLength(3);
+    // ソート順が偏差値の降順になっているか確認
+    const sorted = [...result].sort(
+      (a, b) => b.minAndtotalAreaDeviation - a.minAndtotalAreaDeviation,
+    );
+    expect(result.map((v) => v.minAndtotalAreaDeviation)).toEqual(
+      sorted.map((v) => v.minAndtotalAreaDeviation),
+    );
   });
 });

--- a/src/libs/grid.ts
+++ b/src/libs/grid.ts
@@ -205,29 +205,34 @@ export function sortOptimalLayout({
     });
   });
 
-  // min, totalの合計値を計算
-  let minAreaSum = 0;
-  let totalAreaSum = 0;
-  result.forEach((item) => {
-    minAreaSum += item.contentArea.min;
-    totalAreaSum += item.contentArea.total;
-  });
+  // 平均と分散を1回のreduceで計算
+  const {
+    minSum,
+    totalSum,
+    minSquareSum,
+    totalSquareSum,
+  } = result.reduce(
+    (acc, item) => {
+      const min = item.contentArea.min;
+      const total = item.contentArea.total;
+      acc.minSum += min;
+      acc.totalSum += total;
+      acc.minSquareSum += min * min;
+      acc.totalSquareSum += total * total;
+      return acc;
+    },
+    { minSum: 0, totalSum: 0, minSquareSum: 0, totalSquareSum: 0 },
+  );
 
-  // min, totalの平均値を計算
-  const minAreaAverage = minAreaSum / result.length;
-  const totalAreaAverage = totalAreaSum / result.length;
+  const minAreaAverage = minSum / result.length;
+  const totalAreaAverage = totalSum / result.length;
 
-  // 分散を計算
-  let minVariance = 0;
-  let totalVariance = 0;
-  result.forEach((item) => {
-    minVariance += Math.pow(item.contentArea.min - minAreaAverage, 2);
-    totalVariance += Math.pow(item.contentArea.total - totalAreaAverage, 2);
-  });
-
-  // 分散のsqrtを計算
-  minVariance = Math.sqrt(minVariance / result.length);
-  totalVariance = Math.sqrt(totalVariance / result.length);
+  const minVariance = Math.sqrt(
+    Math.max(minSquareSum / result.length - minAreaAverage ** 2, 0),
+  );
+  const totalVariance = Math.sqrt(
+    Math.max(totalSquareSum / result.length - totalAreaAverage ** 2, 0),
+  );
 
   // 偏差値を計算
   const result2 = result.map((item) => {


### PR DESCRIPTION
## 概要
- `src/libs/grid.ts` の `sortOptimalLayout` で平均と分散の計算を `reduce` で一度のループにまとめました
- それに伴い `src/libs/grid.test.ts` にテストを追加しました

## テスト結果
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm vitest run`
