### PR TITLE
全体制御パネルにチャット一括表示トグルを追加

### DIFF
--- a/src/components/GlobalMenu.vue
+++ b/src/components/GlobalMenu.vue
@@ -48,7 +48,7 @@ const isAnyChatShown = computed(() =>
 );
 
 // 全動画のチャット表示を一括切替（1つでも表示中なら全非表示、なければ全表示）
-// ライブ判定は各動画側が行うため、ここではコマンドを送るだけ
+// 表示可否の処理は各動画側に委ねるため、ここではコマンドを送るだけ
 function toggleAllChat() {
   playerStore.setAllChatVisibility(!isAnyChatShown.value);
 }

--- a/src/components/GlobalMenu.vue
+++ b/src/components/GlobalMenu.vue
@@ -4,6 +4,8 @@ import { computed, ref } from "vue";
 import { usePlayerStore } from "../stores/playerStore";
 import { useVideoListStore } from "../stores/videoListStore";
 import VideoUrlInput from "./VideoUrlInput.vue";
+import IconEllipsesBubble from "~icons/f7/ellipses-bubble";
+import IconEllipsesBubbleFill from "~icons/f7/ellipses-bubble-fill";
 import IconClose from "~icons/mdi/close";
 import IconDotsVertical from "~icons/mdi/dots-vertical";
 import IconFastForward from "~icons/mdi/fast-forward";
@@ -38,6 +40,21 @@ function toggleOpen() {
 
 function onVideoUrlSubmit() {
   editListPopoverEl.value?.hidePopover();
+}
+
+// チャットを表示中の動画が1つでもあるか
+const isAnyChatShown = computed(() =>
+  [...videoListStore.videoOptionsMap.values()].some((options) => options.showChat),
+);
+
+// 全動画のチャット表示を一括切替（1つでも表示中なら全非表示、なければ全表示）
+function toggleAllChat() {
+  const show = !isAnyChatShown.value;
+  playerStore.playerMap.forEach((player, videoId) => {
+    // チャットはライブ配信（durationが0）のみ表示できるため、表示時は非ライブをスキップ
+    if (show && player.getDuration() !== 0) return;
+    videoListStore.setVideoOptions(videoId, { showChat: show });
+  });
 }
 </script>
 
@@ -139,6 +156,20 @@ function onVideoUrlSubmit() {
           <p class="absolute bottom-0 text-xs font-bold">
             {{ playerStore.isSyncSeek ? "ON" : "OFF" }}
           </p>
+        </button>
+      </div>
+      <div class="flex items-center">
+        コメント一括
+        <button
+          :disabled="!hasVideos"
+          class="relative grid size-11 place-items-center rounded-full hover:bg-yellow-200 disabled:opacity-20"
+          @click="toggleAllChat"
+          title="Toggle all chats"
+        >
+          <component
+            :is="isAnyChatShown ? IconEllipsesBubbleFill : IconEllipsesBubble"
+            class="size-8"
+          />
         </button>
       </div>
       <div class="flex items-center">

--- a/src/components/GlobalMenu.vue
+++ b/src/components/GlobalMenu.vue
@@ -48,13 +48,9 @@ const isAnyChatShown = computed(() =>
 );
 
 // 全動画のチャット表示を一括切替（1つでも表示中なら全非表示、なければ全表示）
+// ライブ判定は各動画側が行うため、ここではコマンドを送るだけ
 function toggleAllChat() {
-  const show = !isAnyChatShown.value;
-  playerStore.playerMap.forEach((player, videoId) => {
-    // チャットはライブ配信（durationが0）のみ表示できるため、表示時は非ライブをスキップ
-    if (show && player.getDuration() !== 0) return;
-    videoListStore.setVideoOptions(videoId, { showChat: show });
-  });
+  playerStore.setAllChatVisibility(!isAnyChatShown.value);
 }
 </script>
 

--- a/src/components/PlayerMenu.vue
+++ b/src/components/PlayerMenu.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   reload: [];
+  toggleChat: [];
 }>();
 
 const playerStore = usePlayerStore();
@@ -102,9 +103,9 @@ function onDragend(_e: DragEvent) {
   videoListStore.draggingVideoId = null;
 }
 
+// チャット表示の書き込みは親（YoutubePlayer）のコマンド処理に委ねる
 function toggleChat() {
-  const showChat = videoOptions.value?.showChat;
-  videoListStore.setVideoOptions(props.videoId, { showChat: !showChat });
+  emit("toggleChat");
 }
 
 function reload() {

--- a/src/components/YoutubePlayer.vue
+++ b/src/components/YoutubePlayer.vue
@@ -48,11 +48,17 @@ function onReady(evt: YT.PlayerEvent) {
   playerStore.setLiveStatus(props.videoId, player.getDuration() === 0);
 }
 
-// 全体制御からのチャット表示コマンドを処理する
-// 個別ボタン（v-if="isLive"）と同じく、表示できるのはライブ配信のみ
+// チャット表示コマンドを処理する（全体制御・個別ボタン共通の経路）
+// 表示できるのはライブ配信のみ
 function setChatVisibility(show: boolean) {
   if (show && !isLive.value) return;
   videoListStore.setVideoOptions(props.videoId, { showChat: show });
+}
+
+// 個別ボタンのトグルも同じコマンド処理を経由させる
+function toggleChat() {
+  const showChat = videoListStore.videoOptionsMap.get(props.videoId)?.showChat;
+  setChatVisibility(!showChat);
 }
 
 function onVolumeChange(evt: YT.OnVolumeChangeEvent) {
@@ -220,6 +226,7 @@ onBeforeUnmount(() => {
       :isMuted="isMuted"
       :isLive="isLive"
       @reload="reloadPlayer"
+      @toggle-chat="toggleChat"
     />
   </div>
 </template>

--- a/src/components/YoutubePlayer.vue
+++ b/src/components/YoutubePlayer.vue
@@ -19,7 +19,8 @@ const playerContainer = ref<HTMLElement | null>(null);
 const player = ref<YT.Player | null>(null);
 const isMuted = ref(true);
 const isPaused = ref(true);
-const isLive = ref(false);
+// ライブ判定は playerStore の確定値を参照する（onReady 前は undefined = 非ライブ扱い）
+const isLive = computed(() => playerStore.liveStatusMap.get(props.videoId) === true);
 const volume = ref(0);
 const currentTime = ref(0);
 
@@ -43,8 +44,8 @@ function onReady(evt: YT.PlayerEvent) {
   const player = evt.target;
 
   // 動画の長さが0の場合はライブ配信
-  const duration = player.getDuration();
-  isLive.value = duration === 0;
+  // 再生開始後の getDuration() はライブでも経過時間（非0）を返すため、onReady 時点で確定させる
+  playerStore.setLiveStatus(props.videoId, player.getDuration() === 0);
 }
 
 // 全体制御からのチャット表示コマンドを処理する

--- a/src/components/YoutubePlayer.vue
+++ b/src/components/YoutubePlayer.vue
@@ -47,6 +47,13 @@ function onReady(evt: YT.PlayerEvent) {
   isLive.value = duration === 0;
 }
 
+// 全体制御からのチャット表示コマンドを処理する
+// 個別ボタン（v-if="isLive"）と同じく、表示できるのはライブ配信のみ
+function setChatVisibility(show: boolean) {
+  if (show && !isLive.value) return;
+  videoListStore.setVideoOptions(props.videoId, { showChat: show });
+}
+
 function onVolumeChange(evt: YT.OnVolumeChangeEvent) {
   const data = evt.data;
   volume.value = data.volume;
@@ -165,6 +172,7 @@ async function initializePlayer() {
 
   player.value = ytPlayer;
   playerStore.addPlayer(props.videoId, ytPlayer);
+  playerStore.addChatHandler(props.videoId, setChatVisibility);
 }
 
 // プレーヤーの破棄処理を共通化
@@ -173,6 +181,7 @@ function destroyPlayer() {
 
   if (player.value) {
     playerStore.removePlayer(props.videoId);
+    playerStore.removeChatHandler(props.videoId);
     player.value.destroy();
     player.value = null;
   }

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -8,6 +8,10 @@ export const usePlayerStore = defineStore("playerStore", () => {
   // ライブ判定は各動画コンポーネントが持つため、全体操作はコマンドを送るだけにする
   const chatHandlerMap = ref<Map<string, (show: boolean) => void>>(new Map());
 
+  // 動画ごとのライブ判定（onReady 時点で確定した値）
+  // getDuration() はライブ配信の再生中に経過時間（非0）を返すため、実行時評価では判定できない
+  const liveStatusMap = ref<Map<string, boolean>>(new Map());
+
   // シーク時に全動画を一緒に動かすかどうか
   const isSyncSeek = ref(false);
   // ユーザーが操作中の動画のID
@@ -24,6 +28,12 @@ export const usePlayerStore = defineStore("playerStore", () => {
   // プレイヤーを削除
   function removePlayer(videoId: string) {
     playerMap.value.delete(videoId);
+    liveStatusMap.value.delete(videoId);
+  }
+
+  // ライブ判定を記録（onReady 時点で確定させる）
+  function setLiveStatus(videoId: string, isLive: boolean) {
+    liveStatusMap.value.set(videoId, isLive);
   }
 
   // チャット表示コマンドハンドラーを登録
@@ -76,8 +86,8 @@ export const usePlayerStore = defineStore("playerStore", () => {
       // ignoreIdが指定されている場合はそのIDはスキップ
       if (videoId === ignoreId) return;
 
-      // ライブ中ならシークしない
-      if (player.getDuration() === 0) return;
+      // ライブ中ならシークしない。onReady 前で判定が未確定（undefined）の場合もスキップ
+      if (liveStatusMap.value.get(videoId) !== false) return;
 
       const time = player.getCurrentTime();
       player.seekTo(time + offset, true);
@@ -89,11 +99,13 @@ export const usePlayerStore = defineStore("playerStore", () => {
   }
   return {
     playerMap,
+    liveStatusMap,
     isSyncSeek,
     activeVideoId,
     toggleSyncSeek,
     addPlayer,
     removePlayer,
+    setLiveStatus,
     addChatHandler,
     removeChatHandler,
     setAllChatVisibility,

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -5,7 +5,7 @@ export const usePlayerStore = defineStore("playerStore", () => {
   const playerMap = ref<Map<string, YT.Player>>(new Map());
 
   // 動画ごとのチャット表示コマンドハンドラー
-  // ライブ判定は各動画コンポーネントが持つため、全体操作はコマンドを送るだけにする
+  // 全体操作は各動画へのコマンド送信のみ行い、表示可否の判断と書き込みは各動画側の処理に委ねる設計
   const chatHandlerMap = ref<Map<string, (show: boolean) => void>>(new Map());
 
   // 動画ごとのライブ判定（onReady 時点で確定した値）

--- a/src/stores/playerStore.ts
+++ b/src/stores/playerStore.ts
@@ -4,6 +4,10 @@ import { ref } from "vue";
 export const usePlayerStore = defineStore("playerStore", () => {
   const playerMap = ref<Map<string, YT.Player>>(new Map());
 
+  // 動画ごとのチャット表示コマンドハンドラー
+  // ライブ判定は各動画コンポーネントが持つため、全体操作はコマンドを送るだけにする
+  const chatHandlerMap = ref<Map<string, (show: boolean) => void>>(new Map());
+
   // シーク時に全動画を一緒に動かすかどうか
   const isSyncSeek = ref(false);
   // ユーザーが操作中の動画のID
@@ -20,6 +24,21 @@ export const usePlayerStore = defineStore("playerStore", () => {
   // プレイヤーを削除
   function removePlayer(videoId: string) {
     playerMap.value.delete(videoId);
+  }
+
+  // チャット表示コマンドハンドラーを登録
+  function addChatHandler(videoId: string, handler: (show: boolean) => void) {
+    chatHandlerMap.value.set(videoId, handler);
+  }
+  // チャット表示コマンドハンドラーを削除
+  function removeChatHandler(videoId: string) {
+    chatHandlerMap.value.delete(videoId);
+  }
+  // 全動画にチャット表示コマンドを送る
+  function setAllChatVisibility(show: boolean) {
+    chatHandlerMap.value.forEach((handler) => {
+      handler(show);
+    });
   }
 
   // 全再生
@@ -75,6 +94,9 @@ export const usePlayerStore = defineStore("playerStore", () => {
     toggleSyncSeek,
     addPlayer,
     removePlayer,
+    addChatHandler,
+    removeChatHandler,
+    setAllChatVisibility,
     playAll,
     pauseAll,
     muteAll,


### PR DESCRIPTION
## 概要

全体制御パネル（GlobalMenu）の展開メニューに、全動画のライブチャットを一括で表示・非表示するトグルボタンを追加する。あわせて、ライブ判定を onReady 時点の確定値に一本化し、同期シークがライブ配信を誤ってシークする既存バグを修正する。

## 背景

チャットの表示切替は各プレイヤーの個別メニュー（PlayerMenu）にしかなく、複数動画を並べているときに 1 つずつ切り替える必要があった。全体制御パネルには playAll / pauseAll / muteAll など一括操作が揃っているため、チャット表示も同じ場所から一括制御できるようにする。

実装の過程で次の問題が判明した。

- 表示用・非表示用の 2 ボタンを並べる案は、メニューの行構造（ラベル + 44px ボタン 1 個）を崩してレイアウトが乱れたため、「連結してシーク」と同型の単一トグルボタンに変更した
- YouTube IFrame API の `getDuration()` はライブ配信の再生中に「配信開始からの経過時間（非 0）」を返すため、クリック時に評価するとライブを非ライブと誤判定し、一括表示が効いたり効かなかったりする不安定な挙動になった。ライブ判定は `onReady` 時点で確定した値を使う必要がある
- 同じ理由で、既存の `seekOffsetAll` が実行時の `getDuration() === 0` でライブを除外していたのも機能しておらず、同期シーク時に混在しているライブ配信までシークされていた。本 PR で判定を確定値に一本化して修正する

## 設計方針

一括操作は各動画へのコマンド送信のみ行い、表示可否の判断と `videoOptionsMap` への書き込みは各動画（YoutubePlayer）側の処理に委ねる。一括操作と個別操作で処理経路を分岐させず、全体制御側に動画ごとの状態判断を持ち込まないための要件（ユーザー指定）。このため GlobalMenu はライブ状態を認識せず、`chatHandlerMap` によるコマンドディスパッチを採用している。個別ボタンのトグルも同じコマンド処理（`setChatVisibility`）を経由し、「チャット表示はライブのみ」の規則は `setChatVisibility` の 1 箇所に集約する。

## 変更内容

### GlobalMenu

- 展開メニューの「連結してシーク」と「動画を追加」の間に「コメント一括」行を追加
- 集約状態 `isAnyChatShown`（チャット表示中の動画が 1 つでもあるか）を `videoOptionsMap` から導出し、アイコン表示（fill = 表示中 / outline = 非表示）に反映。アイコンは PlayerMenu の個別チャットトグルと同じ f7 の ellipses-bubble を使用
- トグル押下時は any 判定で動作: 1 つでも表示中なら全動画のチャットを非表示、すべて非表示なら一括表示
- ライブ判定は持たず、`playerStore.setAllChatVisibility` でコマンドを送るだけ

### playerStore

- `chatHandlerMap` を追加し、動画ごとのチャット表示コマンドハンドラーを登録・削除できるようにする。`setAllChatVisibility(show)` で全ハンドラーにコマンドを一括送信する
- `liveStatusMap` を追加し、`onReady` 時点で確定したライブ判定を動画ごとに保持する（`setLiveStatus` で記録、`removePlayer` で削除）
- `seekOffsetAll` のライブ除外を実行時の `getDuration() === 0` から `liveStatusMap` の確定値に変更。判定未確定（`onReady` 前）の動画もシーク対象外とする

### YoutubePlayer

- コマンドを処理する `setChatVisibility(show)` を定義。表示はライブ配信のみ・非表示は無条件で `videoListStore.setVideoOptions` に書き込む。ハンドラーは `addPlayer` / `removePlayer` と同じライフサイクル（initializePlayer / destroyPlayer）で登録・解除する
- `isLive` をローカル ref から `playerStore.liveStatusMap` を参照する computed に変更し、ライブ判定の保存先を store に一本化。個別チャットボタンの表示条件（`v-if="isLive"`）・チャットコマンドのガード・同期シークの除外がすべて同一の確定値を参照する

### PlayerMenu

- 個別チャットトグルは `videoOptionsMap` への直書きをやめ、`toggleChat` イベントを emit して親（YoutubePlayer）の `setChatVisibility` に委譲。一括・個別が同じ書き込みガードを通る

## 確認事項

- [ ] ライブ配信と通常動画が混在した状態で一括表示したとき、ライブ配信のみチャットが表示されること（再生開始後のライブ配信でも表示されること）
- [ ] 個別メニューでチャットを 1 つだけ表示した状態から一括トグルを押すと、全非表示になること
- [ ] 個別メニューのチャットトグルで表示・非表示が従来どおり切り替わること
- [ ] 連結シーク ON でライブ配信と通常動画が混在しているとき、通常動画をシークしてもライブ配信がシークされないこと
