### PR TITLE
fix(player-menu): ホバー領域をメニューコンテンツにフィットさせ、button に cursor: pointer を復元

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,1 +1,14 @@
 @import "tailwindcss";
+
+/*
+  Tailwind v4 の preflight は button を cursor: default にするため、
+  クリック可能なボタンに pointer を戻す（公式 upgrade guide のスニペット）。
+  disabled 時は「押せない」表現と矛盾しないよう除外する
+  https://tailwindcss.com/docs/upgrade-guide
+*/
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}

--- a/src/components/PlayerMenu.vue
+++ b/src/components/PlayerMenu.vue
@@ -60,7 +60,7 @@ function setMenuTimeout() {
 // ホバーでメニューを開く
 // タッチデバイスではクリック後
 function onMouseenter() {
-  // クリック時に直接メニューないのボタンが押されないように遅らせる
+  // クリック時にメニュー内のボタンが直接押されないよう 1 フレーム遅らせる
   requestAnimationFrame(() => {
     isMenuVisible.value = true;
     setMenuTimeout();

--- a/src/components/PlayerMenu.vue
+++ b/src/components/PlayerMenu.vue
@@ -113,15 +113,21 @@ function reload() {
 </script>
 
 <template>
+  <!--
+    ラッパーは絶対配置の shrink-to-fit で全メニュー（削除・リロード含む）を内包する 1 枚の
+    矩形になり、そこがホバー領域になる。ボタン間の隙間もラッパーの box 内なのでホバーは途切れない。
+    メニューは v-if ではなく visibility で隠す。非表示時もレイアウトサイズを保ってホバーの
+    当たり判定を作りつつ、hidden な要素はヒットテスト対象外なのでボタンは押せない
+  -->
   <div
-    class="absolute inset-0 bottom-auto z-10 flex h-16 items-center justify-center"
+    class="absolute top-0 left-1/2 z-10 flex h-16 -translate-x-1/2 items-center px-4"
     @mouseenter="onMouseenter"
     @mousemove="onMousemove"
     @mouseleave="onMouseleave"
   >
-    <template v-if="isMenuVisible">
+    <div class="flex flex-row items-center gap-4" :class="{ invisible: !isMenuVisible }">
       <div
-        class="relative flex size-fit flex-row items-center justify-center rounded-full bg-white px-4 shadow-md outline-solid"
+        class="flex size-fit flex-row items-center justify-center rounded-full bg-white px-4 shadow-md outline-solid"
       >
         <button
           v-if="canUseDragAndDrop"
@@ -169,33 +175,33 @@ function reload() {
         >
           <component :is="isMuted ? IconVolumeOff : IconVolumeHigh" class="size-8" />
         </button>
+      </div>
 
-        <div class="absolute left-full ml-4 flex flex-row items-center justify-center gap-2">
-          <div
-            class="flex size-fit flex-row items-center justify-center rounded-full bg-white shadow-md outline-solid"
+      <div class="flex flex-row items-center justify-center gap-2">
+        <div
+          class="flex size-fit flex-row items-center justify-center rounded-full bg-white shadow-md outline-solid"
+        >
+          <button
+            class="grid size-10 place-items-center rounded-full hover:bg-gray-200"
+            @click="remove"
+            title="Remove"
           >
-            <button
-              class="grid size-10 place-items-center rounded-full hover:bg-gray-200"
-              @click="remove"
-              title="Remove"
-            >
-              <IconTrashCanOutline class="size-8" />
-            </button>
-          </div>
+            <IconTrashCanOutline class="size-8" />
+          </button>
+        </div>
 
-          <div
-            class="flex size-fit flex-row items-center justify-center rounded-full bg-white shadow-md outline-solid"
+        <div
+          class="flex size-fit flex-row items-center justify-center rounded-full bg-white shadow-md outline-solid"
+        >
+          <button
+            class="grid size-10 place-items-center rounded-full hover:bg-gray-200"
+            @click="reload"
+            title="Reload player"
           >
-            <button
-              class="grid size-10 place-items-center rounded-full hover:bg-gray-200"
-              @click="reload"
-              title="Reload player"
-            >
-              <IconRefresh class="size-8" />
-            </button>
-          </div>
+            <IconRefresh class="size-8" />
+          </button>
         </div>
       </div>
-    </template>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## 概要

動画上部メニューのホバー領域を、動画幅全体からメニューコンテンツの矩形にフィットさせる。あわせて Tailwind v4 で失われた button の `cursor: pointer` をグローバル CSS で復元する。

## 背景

動画上部メニューは `absolute inset-0` の全幅ストリップがホバー領域になっており、動画上部のどこにマウスを置いてもメニューが開いてしまっていた。実際のメニュー部分だけをホバー領域にしたい、というのが発端。

最初の修正でラッパーを shrink-to-fit にしたところ、削除・リロードボタン群が `absolute left-full ml-4` でラッパーの box 外に張り出していたため、メインのピルから右側のボタンへ移動する途中の余白（margin はヒットテスト対象外）で `mouseleave` が発火しメニューが閉じる問題が判明した。ホバー領域は個々のコンテンツではなく、全ボタンを内包する 1 枚の連続した矩形である必要がある。

また作業中に、Tailwind v4 の preflight 変更で button が `cursor: default` になっていることを確認した。公式 upgrade guide のスニペットで v3 相当の pointer を復元する。

## 変更内容

### PlayerMenu のホバー領域

- 削除・リロードボタン群の `absolute left-full` 配置をやめ、メインのピルと同じフレックスフロー（`gap-4`）の兄弟要素に変更
- ホバーハンドラを持つラッパーは `absolute left-1/2 -translate-x-1/2` の shrink-to-fit となり、全メニューを内包する連続矩形がそのままホバー領域になる（ボタン間の隙間もラッパーの box 内なので判定が途切れない）
- メニューの表示切り替えを `v-if` から `visibility`（`invisible` クラス）に変更。非表示時もレイアウトサイズを保ってホバーの当たり判定を作りつつ、hidden 要素はヒットテスト対象外なのでボタンの誤クリックは起きない
- ラッパーに `px-4` を追加し、コンテンツ端から左右 1rem のホバー猶予を持たせた
- 既存コメントの誤字を修正（「クリック時に直接メニューないのボタンが〜」→「クリック時にメニュー内のボタンが直接押されないよう 1 フレーム遅らせる」）

### グローバル CSS

- Tailwind v4 公式 upgrade guide のスニペット（`button:not(:disabled), [role="button"]:not(:disabled) { cursor: pointer }`）を `main.css` に追加。disabled ボタン（並び替えの端到達時など）は `disabled:opacity-20` の「押せない」表現と矛盾しないよう矢印カーソルのまま

## 旧実装からの挙動変更・後退

- メニューを開くトリガー領域が動画幅全体からメニュー矩形 + 左右 1rem に狭まる（これが本 PR の目的）
- 旧実装は「メインのピルが動画中央、削除・リロードはそこから右に張り出す」配置だったが、通常フロー化によりメニュー全体（削除・リロード含む）の中央揃えに変わる。メインのピルは従来位置よりやや左に表示される
- メニューが閉じているときも DOM 上に invisible なメニュー要素が常駐する（旧実装は `v-if` で DOM から除去）

## 確認事項

- [ ] 実画面でメニューの各ボタン間・ピル間の隙間を通過してもメニューが閉じないこと
- [ ] タッチデバイス（またはエミュレーション）でタップによるメニュー開閉が従来通り動くこと
- [ ] ドラッグボタンのカーソルが grab のままであること（cursor: pointer の追加による上書きがないこと）
