### PR TITLE
コメントパネルの縦フルサイズトグル追加とメニュー行のボタン化

### DIFF
--- a/src/components/GlobalMenu.vue
+++ b/src/components/GlobalMenu.vue
@@ -144,47 +144,47 @@ function toggleAllChat() {
           <p class="absolute bottom-0 text-xs font-bold">+10m</p>
         </button>
       </div>
-      <div class="flex items-center">
+      <button
+        :disabled="!hasVideos"
+        class="flex items-center rounded-full pl-3 hover:bg-yellow-200 disabled:opacity-20"
+        @click="playerStore.toggleSyncSeek"
+        title="Sync seek"
+      >
         連結してシーク
-        <button
-          :disabled="!hasVideos"
-          class="relative grid size-11 place-items-center rounded-full hover:bg-yellow-200 disabled:opacity-20"
-          @click="playerStore.toggleSyncSeek"
-          title="Sync seek"
-        >
+        <span class="relative grid size-11 place-items-center">
           <component
             :is="playerStore.isSyncSeek ? IconToggleSwitch : IconToggleSwitchOffOutline"
             class="size-8"
           />
-          <p class="absolute bottom-0 text-xs font-bold">
+          <span class="absolute bottom-0 text-xs font-bold">
             {{ playerStore.isSyncSeek ? "ON" : "OFF" }}
-          </p>
-        </button>
-      </div>
-      <div class="flex items-center">
+          </span>
+        </span>
+      </button>
+      <button
+        :disabled="!hasVideos"
+        class="flex items-center rounded-full pl-3 hover:bg-yellow-200 disabled:opacity-20"
+        @click="toggleAllChat"
+        title="Toggle all chats"
+      >
         コメント一括
-        <button
-          :disabled="!hasVideos"
-          class="relative grid size-11 place-items-center rounded-full hover:bg-yellow-200 disabled:opacity-20"
-          @click="toggleAllChat"
-          title="Toggle all chats"
-        >
+        <span class="relative grid size-11 place-items-center">
           <component
             :is="isAnyChatShown ? IconEllipsesBubbleFill : IconEllipsesBubble"
             class="size-8"
           />
-        </button>
-      </div>
-      <div class="flex items-center">
+        </span>
+      </button>
+      <button
+        class="flex items-center rounded-full pl-3 hover:bg-yellow-200"
+        popovertarget="editListPopover"
+        title="Edit video list"
+      >
         リストを編集
-        <button
-          class="grid size-11 place-items-center rounded-full hover:bg-yellow-200"
-          popovertarget="editListPopover"
-          title="Edit video list"
-        >
+        <span class="grid size-11 place-items-center">
           <IconPlaylistEdit class="size-8" />
-        </button>
-      </div>
+        </span>
+      </button>
 
       <div
         popover

--- a/src/components/YoutubeLiveChat.vue
+++ b/src/components/YoutubeLiveChat.vue
@@ -25,7 +25,10 @@ const authorWidth = 40;
 const containerPadding = 8;
 // 縦サイズ（通常時 / フル表示時）
 const halfHeight = "40%";
-const fullHeight = "100%";
+// フル表示でも下端をセル境界から離し、丸角と輪郭を見せる
+// （グリッドは gap なしなので、100% にすると縦に並んだ隣接セルのチャットと地続きに見える）
+const fullHeightBottomGap = 12;
+const fullHeight = `calc(100% - ${fullHeightBottomGap}px)`;
 
 const clipTop = headerHeight + tickerHeight + pinnedHeight;
 const clipBottom = footerHeight;
@@ -45,7 +48,7 @@ const clipStyle = {
 // 左右どちらに配置するか
 const isRight = ref(false);
 // 縦フルサイズ表示か
-const isFullHeight = ref(false);
+const isFullHeight = ref(true);
 
 const containerStyle = computed(() => {
   return {

--- a/src/components/YoutubeLiveChat.vue
+++ b/src/components/YoutubeLiveChat.vue
@@ -23,8 +23,8 @@ const msgPaddingWidth = 24;
 const authorWidth = 40;
 
 const containerPadding = 8;
-// 縦サイズ（通常時 / フル表示時）
-const halfHeight = "40%";
+// 縮小表示時の縦サイズ
+const collapsedHeight = "40%";
 // フル表示でも下端をセル境界から離し、丸角と輪郭を見せる
 // （グリッドは gap なしなので、100% にすると縦に並んだ隣接セルのチャットと地続きに見える）
 const fullHeightBottomGap = 12;
@@ -52,7 +52,7 @@ const isFullHeight = ref(true);
 
 const containerStyle = computed(() => {
   return {
-    height: isFullHeight.value ? fullHeight : halfHeight,
+    height: isFullHeight.value ? fullHeight : collapsedHeight,
     width: `${clipWidth}px`,
     ...(isRight.value ? { right: 0 } : { left: 0 }),
   };
@@ -89,6 +89,7 @@ function toggleFullHeight() {
       class="group/btn absolute top-1/2 grid size-11 -translate-y-1/2 place-items-center opacity-0 transition-opacity group-hover:opacity-100"
       :class="isRight ? 'left-0' : 'right-0'"
       @click="togglePosition"
+      title="Toggle position"
     >
       <div
         class="grid size-7 place-items-center rounded-full border border-white/40 bg-black/60 shadow-md backdrop-blur-sm transition-transform group-hover/btn:scale-110"
@@ -100,6 +101,7 @@ function toggleFullHeight() {
     <button
       class="group/btn absolute bottom-0 left-1/2 grid size-11 -translate-x-1/2 place-items-center opacity-0 transition-opacity group-hover:opacity-100"
       @click="toggleFullHeight"
+      title="Toggle height"
     >
       <div
         class="grid size-7 place-items-center rounded-full border border-white/40 bg-black/60 shadow-md backdrop-blur-sm transition-transform group-hover/btn:scale-110"

--- a/src/components/YoutubeLiveChat.vue
+++ b/src/components/YoutubeLiveChat.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import IconChevronDown from "~icons/mdi/chevron-down";
 import IconChevronLeft from "~icons/mdi/chevron-left";
 import IconChevronRight from "~icons/mdi/chevron-right";
+import IconChevronUp from "~icons/mdi/chevron-up";
 
 const props = defineProps<{
   videoId: string;
@@ -21,7 +23,9 @@ const msgPaddingWidth = 24;
 const authorWidth = 40;
 
 const containerPadding = 8;
-const containerHeight = "40%";
+// 縦サイズ（通常時 / フル表示時）
+const halfHeight = "40%";
+const fullHeight = "100%";
 
 const clipTop = headerHeight + tickerHeight + pinnedHeight;
 const clipBottom = footerHeight;
@@ -40,10 +44,12 @@ const clipStyle = {
 
 // 左右どちらに配置するか
 const isRight = ref(false);
+// 縦フルサイズ表示か
+const isFullHeight = ref(false);
 
 const containerStyle = computed(() => {
   return {
-    height: containerHeight,
+    height: isFullHeight.value ? fullHeight : halfHeight,
     width: `${clipWidth}px`,
     ...(isRight.value ? { right: 0 } : { left: 0 }),
   };
@@ -60,10 +66,14 @@ const chatUrl = computed(() => {
 function togglePosition() {
   isRight.value = !isRight.value;
 }
+
+function toggleFullHeight() {
+  isFullHeight.value = !isFullHeight.value;
+}
 </script>
 
 <template>
-  <div class="absolute top-0" :style="containerStyle">
+  <div class="group absolute top-0" :style="containerStyle">
     <div
       class="absolute size-full overflow-hidden rounded-b-xl outline-1 -outline-offset-1 outline-white/50 outline-solid"
     >
@@ -71,19 +81,27 @@ function togglePosition() {
         <iframe class="absolute size-full" :src="chatUrl" />
       </div>
     </div>
+    <!-- 左右トグル: 動画中央側の辺の中央（左配置なら右辺、右配置なら左辺）。親セルが overflow-hidden のため辺の内側に収める -->
     <button
-      class="absolute -bottom-6 grid size-11 place-items-center rounded-full"
-      :class="{
-        '-left-1': !isRight,
-        '-right-1': isRight,
-      }"
+      class="group/btn absolute top-1/2 grid size-11 -translate-y-1/2 place-items-center opacity-0 transition-opacity group-hover:opacity-100"
+      :class="isRight ? 'left-0' : 'right-0'"
       @click="togglePosition"
     >
-      <div class="grid size-5 place-items-center bg-zinc-800">
-        <component
-          :is="isRight ? IconChevronLeft : IconChevronRight"
-          class="size-5 text-white/60"
-        />
+      <div
+        class="grid size-7 place-items-center rounded-full border border-white/40 bg-black/60 shadow-md backdrop-blur-sm transition-transform group-hover/btn:scale-110"
+      >
+        <component :is="isRight ? IconChevronLeft : IconChevronRight" class="size-5 text-white" />
+      </div>
+    </button>
+    <!-- 縦サイズトグル: 下辺中央 -->
+    <button
+      class="group/btn absolute bottom-0 left-1/2 grid size-11 -translate-x-1/2 place-items-center opacity-0 transition-opacity group-hover:opacity-100"
+      @click="toggleFullHeight"
+    >
+      <div
+        class="grid size-7 place-items-center rounded-full border border-white/40 bg-black/60 shadow-md backdrop-blur-sm transition-transform group-hover/btn:scale-110"
+      >
+        <component :is="isFullHeight ? IconChevronUp : IconChevronDown" class="size-5 text-white" />
       </div>
     </button>
   </div>


### PR DESCRIPTION
## 概要

コメントパネル（ライブチャット）に縦フルサイズのトグルを追加し、デフォルトを縦フル表示にする。あわせて操作ボタンをパネルホバー時のみ表示するデザインに刷新し、全体メニューのラベル付き 3 項目を行全体クリック可能にする。

## 背景

コメントパネルは動画左側に高さ 40% 固定で表示されており、縦に長く読みたいケースに対応できなかった。また左右トグルボタンが常時表示で、小さな暗いグレーの四角 + 低コントラストのアイコンという見た目のため、うるさいチャット背景の上で非常に見づらかった。

デザイン調整にあたりオーバーレイコントロールのベストプラクティスを調査し、予測不能な背景に載せるコントロールには scrim（暗い半透明の下地）+ 高コントラストのアイコン + backdrop-blur を併用する構成を採用した。

実装後の検証で、縦フル表示の動画セルが縦に並ぶと隣接セルのチャット同士が地続きに見えて境界が分からなくなる問題が見つかった。グリッドは gap なしでセルが密着しているためで、フル表示でも下端に 12px の空隙を残して丸角と輪郭を見せることで対処した。境界線の描画はチャット背後に透ける動画の色次第で沈むため採用していない。

## 変更内容

### コメントパネル（YoutubeLiveChat.vue）

- 縦サイズトグルを追加。40% と縦フルを切り替えられ、デフォルトは縦フル
- 縦フル時の高さは `calc(100% - 12px)`。gap なしグリッドで縦に並んだ隣接セルのチャットと地続きに見えないよう、下端に空隙を残して丸角 + 輪郭を見せる
- 操作ボタンはパネルホバー時のみフェード表示（`group` + `group-hover`）
- 左右トグルボタンは動画中央側の辺の中央（左配置なら右辺、右配置なら左辺）、縦サイズトグルボタンは下辺中央に配置
- ボタンデザインを刷新: `bg-black/60` の正円 scrim + `backdrop-blur` + 白アイコン + `border-white/40` の輪郭 + ホバーで `scale-110`。タップ領域は 44px を維持し視覚円は 28px
- 両トグルボタンに `title` を付与（アイコンのみのボタンのアクセシブル名）

### 全体メニュー（GlobalMenu.vue）

- 「連結してシーク」「コメント一括」「リストを編集」の 3 項目を、ラベルを含む行全体が 1 つの `<button>` になる構造に変更。ラベル部分のクリックでも反応する
- 旧アイコンボタンは表示用の `<span>` に降格し、click / disabled / popovertarget / title は行ボタンへ移動（インタラクティブ要素の入れ子は HTML 不正のため）
- ホバーハイライトと disabled の減光（ラベルを含む行全体）が行単位で適用される

## 旧実装からの挙動変更・後退

- 操作ボタンはホバーを持たないタッチ環境では発見性が低い（タップで hover 状態が入る端末では 1 タップ目で表示される）。本ツールは複窓・ドラッグ配置が前提のデスクトップ主用途のため許容している

## 確認事項

- [ ] 実画面でパネルホバー時にボタンが表示され、左右・縦サイズの切り替えが機能すること
- [ ] 動画を縦に並べて両方縦フルにした際、セル境界が視認できること
- [ ] チャット iframe 上にポインターがある状態でもボタンが表示されること（CSS :hover の祖先伝播に依存）
